### PR TITLE
Moved unnecesary code on Symtable.hs to Preparser.y.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -31,12 +31,12 @@ testLexer = do
 testPreParser :: IO ()
 testPreParser = do
     str <- getContents
-    let(errors, tokens) = scanTokens str
+    let (errors, tokens) = scanTokens str
     unless (null errors) (mapM_ print errors)
     (_, preSymbolTable, errs) <- runRWST (preParse tokens) () ST.initialST
     if null errs
-        then pretty preSymbolTable -- print preSymbolTable
-        else mapM_ putStrLn errs
+        then pretty preSymbolTable
+        else mapM_ pretty errs
 
 testParser :: IO ()
 testParser = do
@@ -51,6 +51,6 @@ testParser = do
                 then do
                     prettyPrintProgram ast
                     pretty finalSt
-            else mapM_ putStrLn errs'
-        else mapM_ putStrLn errs
+            else mapM_ pretty errs'
+        else mapM_ pretty errs
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,7 +4,7 @@ import Westeros.SouthOfTheWall.AST          (prettyPrintProgram)
 import Westeros.SouthOfTheWall.Lexer        (scanTokens)
 import Westeros.SouthOfTheWall.Parser       (parse)
 import Westeros.SouthOfTheWall.PreParser    (preParse)
-import Westeros.SouthOfTheWall.PrettyPrint (prettyToken, prettyST)
+import Westeros.SouthOfTheWall.PrettyPrint  (pretty) 
 
 import qualified Westeros.SouthOfTheWall.Symtable as ST
 
@@ -25,7 +25,7 @@ testLexer = do
     str <- getContents
     let(errors, tokens) = scanTokens str
     case errors of
-        [] -> mapM_ prettyToken tokens 
+        [] -> mapM_ pretty tokens 
         _  -> mapM_ print errors
 
 testPreParser :: IO ()
@@ -35,7 +35,7 @@ testPreParser = do
     unless (null errors) (mapM_ print errors)
     (_, preSymbolTable, errs) <- runRWST (preParse tokens) () ST.initialST
     if null errs
-        then prettyST preSymbolTable -- print preSymbolTable
+        then pretty preSymbolTable -- print preSymbolTable
         else mapM_ putStrLn errs
 
 testParser :: IO ()
@@ -50,7 +50,7 @@ testParser = do
             if null errs'
                 then do
                     prettyPrintProgram ast
-                    prettyST finalSt
+                    pretty finalSt
             else mapM_ putStrLn errs'
         else mapM_ putStrLn errs
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,7 +4,7 @@ import Westeros.SouthOfTheWall.AST          (prettyPrintProgram)
 import Westeros.SouthOfTheWall.Lexer        (scanTokens)
 import Westeros.SouthOfTheWall.Parser       (parse)
 import Westeros.SouthOfTheWall.PreParser    (preParse)
-import Westeros.SouthOfTheWall.PrettyPrint (prettyToken)
+import Westeros.SouthOfTheWall.PrettyPrint (prettyToken, prettyST)
 
 import qualified Westeros.SouthOfTheWall.Symtable as ST
 
@@ -35,7 +35,7 @@ testPreParser = do
     unless (null errors) (mapM_ print errors)
     (_, preSymbolTable, errs) <- runRWST (preParse tokens) () ST.initialST
     if null errs
-        then print preSymbolTable
+        then prettyST preSymbolTable -- print preSymbolTable
         else mapM_ putStrLn errs
 
 testParser :: IO ()
@@ -50,7 +50,7 @@ testParser = do
             if null errs'
                 then do
                     prettyPrintProgram ast
-                    print finalSt
+                    prettyST finalSt
             else mapM_ putStrLn errs'
         else mapM_ putStrLn errs
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,12 +4,11 @@ import Westeros.SouthOfTheWall.AST          (prettyPrintProgram)
 import Westeros.SouthOfTheWall.Lexer        (scanTokens)
 import Westeros.SouthOfTheWall.Parser       (parse)
 import Westeros.SouthOfTheWall.PreParser    (preParse)
-import Westeros.SouthOfTheWall.PrettyPrint
+import Westeros.SouthOfTheWall.PrettyPrint (prettyToken)
 
 import qualified Westeros.SouthOfTheWall.Symtable as ST
-import qualified Westeros.SouthOfTheWall.Tokens as Tk
 
-import Control.Monad.RWS ( RWST(runRWST), when, unless )
+import Control.Monad.RWS ( RWST(runRWST), unless )
 import System.Environment (getArgs)
 
 main :: IO ()
@@ -26,7 +25,7 @@ testLexer = do
     str <- getContents
     let(errors, tokens) = scanTokens str
     case errors of
-        [] -> mapM_ print tokens
+        [] -> mapM_ prettyToken tokens 
         _  -> mapM_ print errors
 
 testPreParser :: IO ()
@@ -47,11 +46,11 @@ testParser = do
     (_, preSymbolTable, errs) <- runRWST (preParse tokens) () ST.initialST
     if null errs
         then do
-            (ast, finalSt, errs) <- runRWST (parse tokens) () preSymbolTable{ST.scopeStack=[1,0]}
-            if null errs
+            (ast, finalSt, errs') <- runRWST (parse tokens) () preSymbolTable{ST.scopeStack=[1,0]}
+            if null errs'
                 then do
                     prettyPrintProgram ast
                     print finalSt
-            else mapM_ putStrLn errs
+            else mapM_ putStrLn errs'
         else mapM_ putStrLn errs
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,6 +4,7 @@ import Westeros.SouthOfTheWall.AST          (prettyPrintProgram)
 import Westeros.SouthOfTheWall.Lexer        (scanTokens)
 import Westeros.SouthOfTheWall.Parser       (parse)
 import Westeros.SouthOfTheWall.PreParser    (preParse)
+import Westeros.SouthOfTheWall.PrettyPrint
 
 import qualified Westeros.SouthOfTheWall.Symtable as ST
 import qualified Westeros.SouthOfTheWall.Tokens as Tk

--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,9 @@ dependencies:
 - array # cccsar
 - containers
 - mtl
+- rainbow 
+- bytestring
+- text
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,16 @@ executables:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    - -Wall
+    - -Wcompat
+    - -Widentities
+    - -Wincomplete-uni-patterns
+    - -Wincomplete-record-updates
+    - -Wredundant-constraints
+    - -Wmissing-export-lists
+    - -Wpartial-fields
+    - -Wmissing-deriving-strategies
+    - -Wunused-packages
     dependencies:
     - acif
 
@@ -50,5 +60,16 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    - -Wall
+    - -Wcompat
+    - -Widentities
+    - -Wincomplete-uni-patterns
+    - -Wincomplete-record-updates
+    - -Wredundant-constraints
+    - -Wmissing-export-lists
+    - -Wpartial-fields
+    - -Wmissing-deriving-strategies
+    - -Wunused-packages
+
     dependencies:
     - acif

--- a/samples/fail/preparser/invalid-nargs-def.got
+++ b/samples/fail/preparser/invalid-nargs-def.got
@@ -1,0 +1,38 @@
+A Song of Ice and Fire:
+
+-- A Fizz Of Buzz --
+
+Table of Contents:
+- Prologue
+- Fizzbuzz II 
+- Fizzbuzz III 
+- Epilogue
+
+Prologue
+Valar Morghulis.
+    Lord Tyrion of House Lanninteger.
+Valar Dohaeris.
+
+Fizzbuzz
+    watches
+        Valued Tywin of House Lanninteger
+    approach from a distance;
+    I must warn you, Lanninteger, Boolton is coming.
+Valar Morghulis.
+Valar Dohaeris.
+
+Fizzbuzz
+    watches
+        Valued Perico of House Bool,
+        Valued Popper of House Lanninteger,
+        Valued Papel of House Starkhar
+    approach from a distance;
+    I must warn you, Lanninteger, Boolton is coming.
+Valar Morghulis.
+Valar Dohaeris.
+
+Epilogue
+Valar Morghulis.
+    A raven has come for Tyrion.
+    No One fight against Fizzbuzz traveling alongside Tyrion with caution.
+Valar Dohaeris.

--- a/scripts/runPP-errors.sh
+++ b/scripts/runPP-errors.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for i in `ls ./samples/fail/preparser/` ; do 
+    echo "$i :" ;
+    echo -e "\t `stack exec acif-exe -- preparse < ../samples/fail/preparser/$i`"; 
+done

--- a/scripts/runPP-errors.sh
+++ b/scripts/runPP-errors.sh
@@ -2,5 +2,5 @@
 
 for i in `ls ./samples/fail/preparser/` ; do 
     echo "$i :" ;
-    echo -e "\t `stack exec acif-exe -- preparse < ../samples/fail/preparser/$i`"; 
+    echo -e "`stack exec acif-exe -- preparse < samples/fail/preparser/$i`"; 
 done

--- a/src/Westeros/SouthOfTheWall/Error.hs
+++ b/src/Westeros/SouthOfTheWall/Error.hs
@@ -1,6 +1,6 @@
 module Westeros.SouthOfTheWall.Error where
 
-import qualified Westeros.SouthOfTheWall.Tokens as Tk (Token (..))
+import qualified Westeros.SouthOfTheWall.Tokens as Tk (Position(..))
 
 data Error 
     = PE ParserError 
@@ -13,11 +13,17 @@ data ParserError
     | FDefinitionWithoutDeclaration String
     | RepeatedAliasName String 
     | FRepeatedDefinitions String     
+    -- ^ Preparser related
 
-    | DeclaredAndNotDefined
-    | InvalidNargsCalls
-    | SameScopeRedefinition
-    | UndefinedIdentifier 
+    | UndefinedFunction String String
+    | RedeclaredParemeter String Tk.Position
+    | RedeclaredName String Tk.Position
+    | UndefinedVar String Tk.Position
+    | InvalidVar String String Tk.Position
+    | RedeclaredVar String Tk.Position
+    | RedeclaredConstant String Tk.Position
+    | ExpectedFunction String String Tk.Position
+    -- ^ Parser related
     deriving Show
 
 data TypeError 

--- a/src/Westeros/SouthOfTheWall/Error.hs
+++ b/src/Westeros/SouthOfTheWall/Error.hs
@@ -3,7 +3,7 @@ module Westeros.SouthOfTheWall.Error where
 import qualified Westeros.SouthOfTheWall.Tokens as Tk (Token (..))
 
 
-data ParserError  
+data ParserError a 
     = FDefinitionWithoutDeclaration
     | FRepeatedDeclarations
     | FRepeatedDefinitions

--- a/src/Westeros/SouthOfTheWall/Error.hs
+++ b/src/Westeros/SouthOfTheWall/Error.hs
@@ -8,15 +8,15 @@ data Error
 
 -- ^ Sorted in occurrence order
 data ParserError
-    = FRepeatedDeclarations String
-    | InvalidNArgsDef String Int
-    | FDefinitionWithoutDeclaration String
-    | RepeatedAliasName String 
-    | FRepeatedDefinitions String     
+    = FRepeatedDeclarations String Tk.Position
+    | FRepeatedDefinitions String Tk.Position
+    | InvalidNArgsDef String Int Tk.Position
+    | FDefinitionWithoutDeclaration String Tk.Position
+    | RepeatedAliasName String Tk.Position
     -- ^ Preparser related
 
-    | UndefinedFunction String String
-    | RedeclaredParemeter String Tk.Position
+    | UndefinedFunction String Tk.Position
+    | RedeclaredParameter String Tk.Position
     | RedeclaredName String Tk.Position
     | UndefinedVar String Tk.Position
     | InvalidVar String String Tk.Position

--- a/src/Westeros/SouthOfTheWall/Error.hs
+++ b/src/Westeros/SouthOfTheWall/Error.hs
@@ -2,16 +2,23 @@ module Westeros.SouthOfTheWall.Error where
 
 import qualified Westeros.SouthOfTheWall.Tokens as Tk (Token (..))
 
+data Error 
+    = PE ParserError 
+    | TE TypeError
 
-data ParserError a 
-    = FDefinitionWithoutDeclaration
-    | FRepeatedDeclarations
-    | FRepeatedDefinitions
-    | RepeatedAliasDefinitions
-    | AliasFunctionNameConflict
+-- ^ Sorted in occurrence order
+data ParserError
+    = FRepeatedDeclarations String
+    | InvalidNArgsDef String Int
+    | FDefinitionWithoutDeclaration String
+    | RepeatedAliasName String 
+    | FRepeatedDefinitions String     
 
     | DeclaredAndNotDefined
     | InvalidNargsCalls
     | SameScopeRedefinition
     | UndefinedIdentifier 
     deriving Show
+
+data TypeError 
+    = Nothing

--- a/src/Westeros/SouthOfTheWall/PrettyPrint.hs
+++ b/src/Westeros/SouthOfTheWall/PrettyPrint.hs
@@ -20,6 +20,8 @@ import qualified Data.Map as M (toList)
 
 import Westeros.SouthOfTheWall.Symtable ( SymbolTable(dict, scopeStack, nextScope), SymbolInfo(category, scope, additional) )
 import Westeros.SouthOfTheWall.Tokens (Token(..), Position(..))
+import Westeros.SouthOfTheWall.Error (ParserError(..))
+
 
 
 -- ^ Interface for pretty things
@@ -82,6 +84,27 @@ symbolInfoChunk si = [ chunk "\n\tCategory: "
                      , chunkFromStr $ "\n\tScope: " ++ show (scope si)
                      ]
 
+
+{- Pretty printing for errors -}
+
+instance Pretty ParserError where
+    -- ^ PreParser related
+    pretty (FRepeatedDeclarations fName) = undefined
+    -- ^ "A function with the same name \""++name++"\" and # of arguments was already declared"
+    pretty (InvalidNArgsDef fName nArgs) = undefined
+    -- ^ ("No function \"" ++ functionId ++ "\" with "++ show (length $2) ++ " arguments was declared") -- InvalidNArgsDef _ _
+    pretty (FDefinitionWithoutDeclaration fName) = undefined
+    -- ^ "Function "++functionId++" defined, but not declared"
+    pretty (RepeatedAliasName aName) = undefined
+    -- ^ "The name \""++name++"\" is an existing symbol"
+    pretty (FRepeatedDefinitions fName) = undefined
+    -- ^ ST.insertError ("Function \"" ++ functionId ++ "\" was already defined") -- FRepeatedDefinitions _
+
+    -- ^ Parser related
+    pretty DeclaredAndNotDefined = undefined
+    pretty InvalidNargsCalls = undefined
+    pretty SameScopeRedefinition = undefined
+    pretty UndefinedIdentifier  = undefined
 
 {-
 :set -XOverloadedStrings

--- a/src/Westeros/SouthOfTheWall/PrettyPrint.hs
+++ b/src/Westeros/SouthOfTheWall/PrettyPrint.hs
@@ -1,29 +1,103 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Westeros.SouthOfTheWall.PrettyPrint where
 
+import Data.Function ((&))
+import Data.List (intercalate)
+import Data.Text (pack)
+import Rainbow
+    ( fore,
+      blue,
+      green,
+      red,
+      chunksToByteStrings,
+      toByteStringsColors256,
+      chunk,
+      Chunk )
+
+import qualified Data.ByteString.Char8 as BS
 import qualified Data.Map as M (toList) 
 
 import Westeros.SouthOfTheWall.Symtable ( SymbolTable(dict, scopeStack, nextScope), SymbolInfo(category, scope, additional) )
 import Westeros.SouthOfTheWall.Tokens (Token(..), Position(..))
-import Data.List (intercalate)
+
+
+chunkFromStr :: String -> Chunk 
+chunkFromStr = chunk . pack
+
+{- Pretty printing for Tokens -}
+
+prettyToken :: Token -> IO ()
+prettyToken tk = BS.putStrLn (BS.concat tkBs)
+    where tkBs = chunksToByteStrings toByteStringsColors256 (tokenChunks tk)
+
+
+tokenChunks :: Token -> [Chunk]
+tokenChunks token = [ chunk "-Token "
+                    , chunkFromStr (show $ aToken token) & fore green
+                    , chunkFromStr $ "\n\tContents " 
+                        ++ show (cleanedString  token) 
+                        ++ "\n\tAt row: "
+                    , chunkFromStr (show $ row $ position token) & fore red
+                    , chunk " column: "
+                    , chunkFromStr (show $ col $ position token) & fore red
+                    ]
 
 
 {- Pretty printing for ST -}
 
 instance Show SymbolInfo where
-    show = prettySymbolInfo 1
+    show = prettySymbolInfo
 
-prettySymbolInfo :: Int -> SymbolInfo -> String
-prettySymbolInfo n si = preTb "Category: " ++ show (category si) ++ "\n"
-                     ++ preTb "Scope : " ++ show ( scope si )  ++ "\n"
-                     ++ preTb "extra: " ++ show ( additional si ) ++ "\n"
-    where preTb = (replicate n '\t' ++)
+prettySymbolInfo :: SymbolInfo -> String
+prettySymbolInfo si = "\tCategory: " ++ show (category si) ++ "\n"
+                     ++ "\tScope : " ++ show ( scope si )  ++ "\n"
 
+symbolInfoChunk :: SymbolInfo -> [Chunk]
+symbolInfoChunk si = [ chunk "\tCategory: " 
+                     , chunkFromStr (show (category si)) & fore blue
+                     , chunk "\n\tScope: "
+                     , chunkFromStr (show (scope si) ) & fore red 
+                     ]
 
 instance Show SymbolTable where
-    show st = "* Name info\n\n" ++ displayDict
+    show st = "* Name info\n" ++ displayDict
               ++ "* Scope stack: " ++ show (scopeStack st)
               ++ "\n* Next scope: " ++ show (nextScope st)
         where
             displayDict  = foldl (\acc (b,c) -> acc ++ b ++ '\n' : splitInfo c) [] $ M.toList (dict st)
             splitInfo = intercalate bar . map show
             bar = "\t\n-------------------\n"
+
+const = 252
+
+{-
+:set -XOverloadedStrings
+
+import Data.Function ((&))
+
+Rainbow
+putChunkLn $ "Some blue text" & fore blue
+color256 :: Word8 -> Radiant
+
+import Data.Text
+pack :: String -> Text
+
+import qualified Data.ByteString as BS
+
+toByteStringsColors0 :: Chunk -> [ByteString] -> [ByteString]
+
+toByteStringsColors8 :: Chunk -> [ByteString] -> [ByteString]
+
+toByteStringsColors256 :: Chunk -> [ByteString] -> [ByteString]
+
+EXAMPLE
+
+myChunks :: [Chunk String]
+myChunks = [ chunk "Roses" & fore red, chunk "\n",
+             chunk "Violets" & fore blue, chunk "\n" ]
+
+myPrintedChunks :: IO ()
+myPrintedChunks = mapM_ BS.putStr . chunksToByteStrings toByteStringsColors256 $ myChunks
+
+-}

--- a/src/Westeros/SouthOfTheWall/PrettyPrint.hs
+++ b/src/Westeros/SouthOfTheWall/PrettyPrint.hs
@@ -3,7 +3,11 @@ module Westeros.SouthOfTheWall.PrettyPrint where
 import qualified Data.Map as M (toList) 
 
 import Westeros.SouthOfTheWall.Symtable ( SymbolTable(dict, scopeStack, nextScope), SymbolInfo(category, scope, additional) )
+import Westeros.SouthOfTheWall.Tokens (Token(..), Position(..))
 import Data.List (intercalate)
+
+
+{- Pretty printing for ST -}
 
 instance Show SymbolInfo where
     show = prettySymbolInfo 1
@@ -22,4 +26,4 @@ instance Show SymbolTable where
         where
             displayDict  = foldl (\acc (b,c) -> acc ++ b ++ '\n' : splitInfo c) [] $ M.toList (dict st)
             splitInfo = intercalate bar . map show
-            bar = "\n-------------------\n"
+            bar = "\t\n-------------------\n"

--- a/src/Westeros/SouthOfTheWall/PrettyPrint.hs
+++ b/src/Westeros/SouthOfTheWall/PrettyPrint.hs
@@ -1,0 +1,25 @@
+module Westeros.SouthOfTheWall.PrettyPrint where
+
+import qualified Data.Map as M (toList) 
+
+import Westeros.SouthOfTheWall.Symtable ( SymbolTable(dict, scopeStack, nextScope), SymbolInfo(category, scope, additional) )
+import Data.List (intercalate)
+
+instance Show SymbolInfo where
+    show = prettySymbolInfo 1
+
+prettySymbolInfo :: Int -> SymbolInfo -> String
+prettySymbolInfo n si = preTb "Category: " ++ show (category si) ++ "\n"
+                     ++ preTb "Scope : " ++ show ( scope si )  ++ "\n"
+                     ++ preTb "extra: " ++ show ( additional si ) ++ "\n"
+    where preTb = (replicate n '\t' ++)
+
+
+instance Show SymbolTable where
+    show st = "* Name info\n\n" ++ displayDict
+              ++ "* Scope stack: " ++ show (scopeStack st)
+              ++ "\n* Next scope: " ++ show (nextScope st)
+        where
+            displayDict  = foldl (\acc (b,c) -> acc ++ b ++ '\n' : splitInfo c) [] $ M.toList (dict st)
+            splitInfo = intercalate bar . map show
+            bar = "\n-------------------\n"

--- a/src/Westeros/SouthOfTheWall/PrettyPrint.hs
+++ b/src/Westeros/SouthOfTheWall/PrettyPrint.hs
@@ -30,6 +30,7 @@ class Pretty a where
 
 -- ^ Get a lazy bytestring from a chunk generator 
 --      Chunk generator == output of colored formatted text
+-- OJO: possible bottleneck
 chunksToLazyBS :: (a -> [Chunk]) -> a -> BS.ByteString
 chunksToLazyBS chunker source = printable
     where 
@@ -73,7 +74,7 @@ symTableChunk symT = chunk "* Name info\n"
     where 
         asList = M.toList (dict symT)
         foo (a,b) = (chunkFromStr ('\n':a) & fore green) : preProcess b :: [Chunk]
-            where  -- OJO
+            where  -- OJO: possible bottleneck
                 preProcess = intercalate [chunkFromStr bar] . map symbolInfoChunk 
                 bar = "\n\t-------------------"
 
@@ -100,11 +101,24 @@ instance Pretty ParserError where
     pretty (FRepeatedDefinitions fName) = undefined
     -- ^ ST.insertError ("Function \"" ++ functionId ++ "\" was already defined") -- FRepeatedDefinitions _
 
+    
+    pretty (UndefinedFunction name parameters) = undefined
+    -- ^ "error: undefined function " ++ name ++ "with " ++ (show params) ++ " parameters."
+    pretty (RedeclaredParemeter parName position) = undefined
+    -- ^Error: redeclared parameter " ++ name ++ " at position " ++ show (Tk.position $2)
+    pretty (RedeclaredName name position) = undefined
+    -- "Error: redeclared name " ++ name ++ " at position " ++ show (Tk.position $2)
+    pretty (UndefinedVar name position) = undefined
+    -- "Error: undefined variable " ++ name ++ " at postition " ++ show pos
+    pretty (InvalidVar category unexpectedSym position) = undefined
+    -- "Error: expected variable, found " ++ show c ++ " " ++ name ++ " at position " ++ show pos
+    pretty (RedeclaredVar name position) = undefined
+    -- "Error: redeclared variable " ++ name ++ " at position " ++ show pos
+    pretty (RedeclaredConstant name position) = undefined
+    -- "Error: redeclared constant " ++ name ++ " at position " ++ show pos
+    pretty (ExpectedFunction category name position) = undefined
+    -- "Error: expected function, found " ++ show c ++ " " ++ name ++ " at position " ++ show pos
     -- ^ Parser related
-    pretty DeclaredAndNotDefined = undefined
-    pretty InvalidNargsCalls = undefined
-    pretty SameScopeRedefinition = undefined
-    pretty UndefinedIdentifier  = undefined
 
 {-
 :set -XOverloadedStrings

--- a/src/Westeros/SouthOfTheWall/Symtable.hs
+++ b/src/Westeros/SouthOfTheWall/Symtable.hs
@@ -1,5 +1,7 @@
 module Westeros.SouthOfTheWall.Symtable where
 
+import qualified Westeros.SouthOfTheWall.Error as Err
+
 import qualified Westeros.SouthOfTheWall.Tokens as Tk
 import qualified Westeros.SouthOfTheWall.AST as Ast ( ParamType, AliasType, Type, Parameter )
 import qualified Data.Map.Strict as M
@@ -17,7 +19,7 @@ data PassType = Value | Reference deriving (Show,Eq)
 
 type Dict = M.Map Symbol [SymbolInfo]
 
-type MonadParser = RWST () [String] SymbolTable IO
+type MonadParser = RWST () [Err.Error] SymbolTable IO
 
 data Category 
     = Alias
@@ -148,7 +150,7 @@ currentScope = do
     SymbolTable { scopeStack = (s:_)} <- get
     return s
 
-insertError :: String -> MonadParser ()
+insertError :: Err.Error -> MonadParser ()
 insertError msg = tell [msg]
 
 

--- a/src/Westeros/SouthOfTheWall/Tokens.hs
+++ b/src/Westeros/SouthOfTheWall/Tokens.hs
@@ -199,7 +199,7 @@ data AbstractToken =
 {- Instances -}
 
 instance Show Position where
-    show position = "row :" ++ show (row position) ++ 
+    show position = "row: " ++ show (row position) ++ 
                     " column: " ++ show (col position )
 
 instance Show Token where

--- a/src/Westeros/SouthOfTheWall/Tokens.hs
+++ b/src/Westeros/SouthOfTheWall/Tokens.hs
@@ -14,7 +14,7 @@ data Position = Position {
         row :: Int,
         col :: Int
     }
-    deriving Eq
+    deriving (Eq,Show)
 
 data Token = Token 
     { aToken :: AbstractToken
@@ -22,7 +22,7 @@ data Token = Token
     , cleanedString :: String
     , position :: Position
     }
-    deriving Eq
+    deriving (Eq,Show)
 
 
 
@@ -194,15 +194,3 @@ data AbstractToken =
     -- Comments
     | TknComment
    deriving (Show,Eq)
-
-
-{- Instances -}
-
-instance Show Position where
-    show position = "row: " ++ show (row position) ++ 
-                    " column: " ++ show (col position )
-
-instance Show Token where
-    show token = "-Token " ++ show (aToken token) ++ 
-                 " with contents " ++ show (cleanedString token) ++ 
-                 " at " ++ show (position token)

--- a/src/Westeros/SouthOfTheWall/Tokens.hs
+++ b/src/Westeros/SouthOfTheWall/Tokens.hs
@@ -14,7 +14,7 @@ data Position = Position {
         row :: Int,
         col :: Int
     }
-    deriving (Show, Eq)
+    deriving Eq
 
 data Token = Token 
     { aToken :: AbstractToken
@@ -22,7 +22,9 @@ data Token = Token
     , cleanedString :: String
     , position :: Position
     }
-    deriving (Show, Eq)
+    deriving Eq
+
+
 
 data AbstractToken = 
     -- Program Start
@@ -192,3 +194,15 @@ data AbstractToken =
     -- Comments
     | TknComment
    deriving (Show,Eq)
+
+
+{- Instances -}
+
+instance Show Position where
+    show position = "row :" ++ show (row position) ++ 
+                    " column: " ++ show (col position )
+
+instance Show Token where
+    show token = "-Token " ++ show (aToken token) ++ 
+                 " with contents " ++ show (cleanedString token) ++ 
+                 " at " ++ show (position token)

--- a/src/Westeros/SouthOfTheWall/TypeVer.hs
+++ b/src/Westeros/SouthOfTheWall/TypeVer.hs
@@ -1,0 +1,236 @@
+module Westeros.SouthOfTheWall.TypeVer where
+
+
+{-
+Tipos -> Literales -> Expresiones -> Instrucciones -> Funciones
+------------------------------------------------------------- EXPRESSIONS
+
+Operators
+    ops(int,float): 
+        + | - | * | / | -. | 
+    ops(int): 
+        % 
+    ops(int,bool,float,char): 
+        == | /= | < | > | <= | >=
+    ops(bool): 
+        && | ||
+    ops(all): 
+        */type cast
+
+Parser.y:413
+EXPR :: { Ast.Expression }
+    : EXPR '+' EXPR       
+    | EXPR '-' EXPR       
+    | EXPR '*' EXPR       
+    | EXPR '/' EXPR       
+    | EXPR '%' EXPR       
+    | EXPR '=' EXPR       
+    | EXPR '!=' EXPR      
+    | EXPR '<' EXPR       
+    | EXPR '>' EXPR       
+    | EXPR '<=' EXPR      
+    | EXPR '>=' EXPR      
+    | EXPR and EXPR       
+    | EXPR or EXPR        
+    | EXPR '~'            
+
+    | deref EXPR          
+    | '[' EXPRLIST ']' EXP
+    | id '<-' EXPR        
+    | EXPR '->' id        
+    | EXPR '?' id         
+
+    | '[(' naturalLit ']' 
+    | EXPR cast TYPE      
+    | '(' EXPR ')'        
+    
+    | ARRAYLIT            
+    | TUPLELIT            
+    | FUNCTIONCALL        
+
+    | intLit              
+    | floatLit            
+    | charLit             
+    | atomLit             
+    | stringLit           
+    | true                
+    | false               
+    | null                
+    | id                  
+
+Parser.y:478
+EXPRLIST :: { [Ast.Expression] }
+    : EXPR                      
+    | EXPRLIST ',' EXPR         
+    
+------------------------------------------------------------- DECLARATION
+
+Parser.y:304
+DECLARATION :: { Ast.Declaration }
+    : SIMPLE_DECLARATION '.'                                                 
+    | SIMPLE_DECLARATION ':=' EXPR '.'                                       
+    | SIMPLE_DECLARATION ':==' EXPR '.'                                      
+    | CONST_DECLARATION '.'                                                  
+
+SIMPLE_DECLARATIONS :: { [Ast.VariableDeclaration] }
+    : SIMPLE_DECLARATION                                                     
+    | SIMPLE_DECLARATIONS ',' SIMPLE_DECLARATION                             
+
+SIMPLE_DECLARATION :: { Ast.VariableDeclaration }
+    : PRIMITIVE_DECLARATION                                                  
+    | COMPOSITE_DECLARATION                                                  
+
+PRIMITIVE_DECLARATION :: { Ast.VariableDeclaration }
+    : var id type TYPE                                                       
+
+COMPOSITE_DECLARATION :: { Ast.VariableDeclaration }
+    : beginCompTypeId var id endCompTypeId TYPE                              
+    | beginCompTypeId var id endCompTypeId TYPE beginSz EXPRLIST endSz       
+    | beginCompTypeId pointerVar id endCompTypeId TYPE                       
+    | beginCompTypeId pointerVar id endCompTypeId TYPE beginSz EXPRLIST endSz
+
+CONST_DECLARATION :: { Ast.Declaration }
+    : const id type TYPE constValue EXPR                                     
+    | beginCompTypeId const id endCompTypeId TYPE constValue EXPR            
+
+ALIAS_DECLARATION :: { Ast.AliasDeclaration }
+    : beginAlias id ALIAS_TYPE TYPE '.'                                      
+
+ALIAS_TYPE :: { Ast.AliasType }
+    : strongAlias                                                            
+    | weakAlias                                                              
+
+------------------------------------------------------------- TYPES
+
+Simples: Lanninteger/int | Freyt/float | Boolton/bool | Starkhar/char | Barathom/atom
+
+Parser.y:273
+TYPE :: { Ast.Type }
+    : PRIMITIVE_TYPE                           
+    | COMPOSITE_TYPE                           
+    | id                                       
+
+PRIMITIVE_TYPE :: { Ast.Type }
+    : int                                      
+    | float                                    
+    | char                                     
+    | bool                                     
+    | atom                                     
+
+COMPOSITE_TYPE :: { Ast.Type }
+    : beginArray naturalLit TYPE endArray      
+    | string                                   
+    | pointerType TYPE                         
+    | beginStruct SIMPLE_DECLARATIONS endStruct
+    | beginUnion SIMPLE_DECLARATIONS endUnion  
+    | beginTuple TUPLE_TYPES endTuple          
+
+TUPLE_TYPES :: { [Ast.Type] }
+    : {- empty -}                              
+    | TYPES                                    
+
+------------------------------------------------------------- INSTRUCTIONS
+
+    assignment
+    multiple assignnment
+    simple selection
+    multiple selection
+    determinate repetition
+    undeterminate repetition
+
+
+Parser.y:348
+INSTRUCTION :: { Ast.Instruction }
+    : EXPR ':=' EXPR '.'                                                         
+    | EXPRLIST ':==' EXPR '.'                                                    
+    | void ':=' EXPR '.'                                                         
+    | void ':==' EXPR '.'                                                        
+    | pass '.'                                                                   
+    | beginExit programName endExit '.'                                          
+    | read EXPR '.'                                                              
+    | print EXPR '.'                                                             
+    | EXPR new '.'                                                               
+    | EXPR free '.'                                                              
+    | continue '.'                                                               
+    | break '.'                                                                  
+    | returnOpen EXPRLIST returnClose                                            
+    | returnOpen returnClose                                                     
+    | IF '.'                                                                     
+    | SWITCHCASE '.'                                                             
+    | FOR '.'                                                                    
+    | WHILE '.'                                                                  
+    | DECLARATION                                                                
+
+IF :: { Ast.IfInst }
+    : if EXPR then CODE_BLOCK endif                                              
+    | if EXPR then CODE_BLOCK else CODE_BLOCK endif                              
+
+SWITCHCASE :: { Ast.Instruction }
+    : switch EXPR switchDec '.' CASES endSwitch                                  
+
+CASES :: { [Ast.Case] }
+    : CASE                                                                       
+    | CASES CASE                                                                 
+
+CASE :: { Ast.Case }
+    : case atomLit '.' CODE_BLOCK                                                
+    | case nothing '.' CODE_BLOCK                                                
+
+FOR :: { Ast.Instruction }
+    : OPEN_SCOPE FOR_DEC INSTRUCTIONS endFor CLOSE_SCOPE                         
+
+FOR_DEC :: { (Ast.Id, Ast.Expression, Ast.Expression) }
+    : for id type int '.' forLB EXPR forUB EXPR '.'                              
+                                                                                 
+WHILE :: { Ast.Instruction }
+    : while EXPR whileDec CODE_BLOCK endWhile                                    
+                                                                                 
+------------------------------------------------------------- FUNCTIONS
+
+Function definition
+Function call
+
+Parser.y:219
+FUNCTIONS :: { [Ast.FunctionDeclaration] }
+    : {- empty -}                                                                
+    | FUNCTIONS FUNCTION                                                         
+
+FUNCTION :: { Ast.FunctionDeclaration }
+    : id OPEN_SCOPE FUNCTION_PARAMETERS FUNCTION_RETURN FUNCTION_BODY CLOSE_SCOPE
+
+FUNCTION_PARAMETERS :: { [Ast.Parameter] }
+    : beginFuncParams PARAMETER_LIST endFuncParams                               
+
+PARAMETER_LIST :: { [Ast.Parameter] }
+    : void                                                                       
+    | PARAMETERS                                                                 
+
+PARAMETERS :: { [Ast.Parameter] }
+    : PARAMETER                                                                  
+    | PARAMETERS ',' PARAMETER                                                   
+
+PARAMETER :: { Ast.Parameter }
+    : PARAMETER_TYPE id type TYPE                                                
+
+PARAMETER_TYPE :: { Ast.ParamType }
+    : valueArg                                                                   
+    | refArg                                                                     
+
+FUNCTION_RETURN :: { [Ast.Type] }
+    : beginReturnVals RETURN_TYPES endReturnVals                                 
+
+RETURN_TYPES :: { [Ast.Type]}
+    : void                                                                       
+    | TYPES                                                                      
+
+Parser.y:465
+FUNCTIONCALL :: { Ast.Expression }
+    : id '((' procCallArgs EXPRLIST '))'
+    | id '((' procCallArgs void '))'    
+    | id '(('  '))'                     
+
+
+
+Compound:  .. later
+
+-}


### PR DESCRIPTION
Created a file for pretty print and moved show instances for types there.
Now symtable only holds organized datatypes and relevant functions.